### PR TITLE
Move items from the controller to the silo

### DIFF
--- a/src/main/java/de/presti/ccbx/ccbx/CCBXItemStackHandler.java
+++ b/src/main/java/de/presti/ccbx/ccbx/CCBXItemStackHandler.java
@@ -1,0 +1,82 @@
+package de.presti.ccbx.ccbx;
+
+import ballistix.common.block.BlockExplosive;
+import ballistix.common.item.ItemMissile;
+import electrodynamics.common.blockitem.BlockItemDescriptable;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.ItemStackHandler;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Item stack handler of a silo controller.
+ */
+public class CCBXItemStackHandler extends ItemStackHandler {
+    /**
+     * The tile entity of the silo controller.
+     */
+    private final CCBallistiXTileEntity tileEntity;
+
+    /**
+     * Creates a new item stack handler for a silo controller.
+     *
+     * @param tileEntity The tile entity of the silo controller
+     */
+    public CCBXItemStackHandler(CCBallistiXTileEntity tileEntity) {
+        super(2);
+        this.tileEntity = tileEntity;
+    }
+
+    /**
+     * Called when the contents of the inventory have changed.
+     *
+     * @param slot The slot that changed
+     */
+    @Override
+    protected void onContentsChanged(int slot) {
+        super.onContentsChanged(slot);
+        this.tileEntity.setChanged();
+    }
+
+    /**
+     * Inserts an ItemStack into the given slot and returns the remainder.
+     *
+     * @param slot     Slot to insert into.
+     * @param stack    ItemStack to insert. This must not be modified by the item handler.
+     * @param simulate If true, the insertion is only simulated
+     * @return The remaining stack that was not inserted (if the entire stack is accepted, then return ItemStack.EMPTY).
+     */
+    @Override
+    public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        var item = stack.getItem();
+        if (item instanceof BlockItemDescriptable des && des.getBlock() instanceof BlockExplosive) {
+            slot = 1;
+        }
+
+        if (item instanceof ItemMissile) {
+            slot = 0;
+        }
+
+        return super.insertItem(slot, stack, simulate);
+    }
+
+    /**
+     * Checks if the given stack is valid for the given slot.
+     *
+     * @param slot  Slot to query for validity
+     * @param stack Stack to test with for validity
+     * @return If the stack is valid for the slot
+     */
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+        var item = stack.getItem();
+
+        if (slot == 0) {
+            return item instanceof ItemMissile;
+        }
+        if (slot == 1) {
+            return item instanceof BlockItemDescriptable des && des.getBlock() instanceof BlockExplosive;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/de/presti/ccbx/ccbx/CCBallistiXBlock.java
+++ b/src/main/java/de/presti/ccbx/ccbx/CCBallistiXBlock.java
@@ -1,15 +1,13 @@
 package de.presti.ccbx.ccbx;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.material.Material;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,5 +31,26 @@ public class CCBallistiXBlock extends Block implements EntityBlock {
     @Override
     public BlockEntity newBlockEntity(@NotNull BlockPos pos, @NotNull BlockState state) {
         return Registration.CC_TILEENTITY.get().create(pos, state);
+    }
+
+    /**
+     * Allows the block entity to tick.
+     *
+     * @param level The level
+     * @param state The state
+     * @param type  The type
+     * @param <T>   The type
+     * @return The ticker
+     */
+    @org.jetbrains.annotations.Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(
+            @NotNull Level level,
+            @NotNull BlockState state,
+            @NotNull BlockEntityType<T> type
+    ) {
+        return type == Registration.CC_TILEENTITY.get() && !level.isClientSide
+                ? (l, p, s, t) -> ((CCBallistiXTileEntity) t).tick()
+                : null;
     }
 }

--- a/src/main/java/de/presti/ccbx/ccbx/CCBallistiXTileEntity.java
+++ b/src/main/java/de/presti/ccbx/ccbx/CCBallistiXTileEntity.java
@@ -1,17 +1,38 @@
 package de.presti.ccbx.ccbx;
 
+import ballistix.common.tile.TileMissileSilo;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import electrodynamics.prefab.tile.components.ComponentType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.ItemStackHandler;
 import org.jetbrains.annotations.NotNull;
 
 import static dan200.computercraft.shared.Capabilities.CAPABILITY_PERIPHERAL;
 
 public class CCBallistiXTileEntity extends BlockEntity {
+
+    /**
+     * A counter to do operations every few ticks.
+     */
+    private int tickCounter = 0;
+
+    /**
+     * The inventory of the block.
+     */
+    private final ItemStackHandler inventory = new CCBXItemStackHandler(this);
+
+    /**
+     * The capability of the inventory.
+     */
+    private final LazyOptional<ItemStackHandler> inventoryCap = LazyOptional.of(() -> inventory);
 
     public CCBallistiXTileEntity(BlockPos pos, BlockState state) {
         super(Registration.CC_TILEENTITY.get(), pos, state);
@@ -22,6 +43,38 @@ public class CCBallistiXTileEntity extends BlockEntity {
      */
     protected CCBallistiXPeripheral peripheral = new CCBallistiXPeripheral(this);
     private LazyOptional<IPeripheral> peripheralCap;
+
+    /**
+     * Loads the inventory.
+     *
+     * @param nbt The tag to load from
+     */
+    @Override
+    public void load(@NotNull CompoundTag nbt) {
+        super.load(nbt);
+
+        try {
+            var data = nbt.getCompound("Buffer");
+            inventory.deserializeNBT(data.getCompound("Inventory"));
+        } catch (Exception e) {
+            // Ignore, just log
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Saves the inventory.
+     *
+     * @param nbt The tag to save to
+     */
+    @Override
+    protected void saveAdditional(@NotNull CompoundTag nbt) {
+        super.saveAdditional(nbt);
+
+        var data = new CompoundTag();
+        data.put("Inventory", inventory.serializeNBT());
+        nbt.put("Buffer", data);
+    }
 
     /**
      * When a computer modem tries to wrap our block, the modem will call getCapability to receive our peripheral.
@@ -36,6 +89,77 @@ public class CCBallistiXTileEntity extends BlockEntity {
             }
             return peripheralCap.cast();
         }
+
+        if (cap == ForgeCapabilities.ITEM_HANDLER) {
+            return inventoryCap.cast();
+        }
+
         return super.getCapability(cap, direction);
+    }
+
+    /**
+     * Moves the items from our inventory to the missile silo above us every 10 ticks.
+     */
+    public void tick() {
+        tickCounter++;
+
+        // Only move items every 10 ticks and if there is something to move
+        if (
+                tickCounter % 10 != 0 ||
+                        (inventory.getStackInSlot(0).isEmpty() && inventory.getStackInSlot(1).isEmpty())
+        ) {
+            return;
+        }
+
+        var silo = getMissileSilo();
+        if (silo == null) {
+            return;
+        }
+
+        var inventoryComponent = silo.getComponent(ComponentType.Inventory);
+        if (inventoryComponent == null) {
+            return;
+        }
+
+        inventoryComponent.getCapability(ForgeCapabilities.ITEM_HANDLER, Direction.UP)
+                .ifPresent(wrapper -> {
+                    // Move the items from our inventory to the missile silo above us
+                    var ourMissileStack = inventory.getStackInSlot(0);
+                    var ourExplosiveStack = inventory.getStackInSlot(1);
+                    var theirMissileStack = wrapper.getStackInSlot(0);
+                    var theirExplosiveStack = wrapper.getStackInSlot(1);
+
+                    if (theirMissileStack.isEmpty() || ourMissileStack.getItem() == theirMissileStack.getItem()) {
+                        var newStack = wrapper.insertItem(0, ourMissileStack, false);
+                        inventory.setStackInSlot(0, newStack);
+                    }
+                    if (theirExplosiveStack.isEmpty() || ourExplosiveStack.getItem() == theirExplosiveStack.getItem()) {
+                        var newStack = wrapper.insertItem(1, ourExplosiveStack, false);
+                        inventory.setStackInSlot(1, newStack);
+                    }
+                });
+    }
+
+    /**
+     * Get the missile silo above this block.
+     *
+     * @return The missile silo above this block or null if there is none
+     */
+    private TileMissileSilo getMissileSilo() {
+        Level level = getLevel();
+        if (level == null) {
+            return null;
+        }
+
+        BlockEntity blockEntity = level.getBlockEntity(getBlockPos().above());
+        if (blockEntity == null) {
+            return null;
+        }
+
+        if (blockEntity instanceof TileMissileSilo tileMissileSilo) {
+            return tileMissileSilo;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Allows the Silo Controller to move items through to the Missile Silo block entity.

Pushing the items from below the silo is the only way of inserting them into it. On top of this, on the 1.19 version of Ballistix even that doesn't work. This makes it impossible to automatically refill the launcher.

My changes offer a way to do this by creating an inventory on the Silo Controller and programatically pushing the items to the silo.